### PR TITLE
fixing broadcasting bug when adding attention mask + kq product

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,6 +7,23 @@
     {
       "type": "lldb",
       "request": "launch",
+      "name": "Debug BERT",
+      
+      "cargo": {
+        "args": ["build",
+        "--bin",
+        "llm", "--features=metal,bert", "--example=bench"],
+        "filter": {
+          "name": "bench",
+          "kind": "example"
+        }
+      },
+      "args": ["--use-gpu=true"],
+      "cwd": "${workspaceFolder}"
+    },
+    {
+      "type": "lldb",
+      "request": "launch",
       "name": "Debug BLOOM Inference",
       "cargo": {
         "args": ["build", "--example=inference", "--package=llm"],

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1305,6 +1305,7 @@ version = "0.2.0-dev"
 dependencies = [
  "bytemuck",
  "llm-base",
+ "num-traits",
  "tracing",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tracing = { version = "0.1", features = ["log"] }
 llm-samplers = "=0.0.6"
 
+
 # Config for 'cargo dist'
 [workspace.metadata.dist]
 # The preferred cargo-dist version to use in CI (Cargo.toml SemVer syntax)

--- a/crates/llm-base/src/inference_session.rs
+++ b/crates/llm-base/src/inference_session.rs
@@ -34,6 +34,8 @@ pub struct GraphOutputs {
 
     /// The output containing embeddings
     pub embedding_result: Tensor,
+
+    
 }
 
 /// An inference session represents the state of the text generation. This holds

--- a/crates/llm-base/src/model/common.rs
+++ b/crates/llm-base/src/model/common.rs
@@ -46,10 +46,10 @@ pub fn extract_embeddings(
 ) {
     // Extract embeddings
     if let Some(embeddings) = &mut output_request.embeddings {
-        embeddings.resize(n_embd * 8 * n, 0.0);
+        embeddings.resize(n_embd  * n, 0.0);
         dbg!(embeddings_tensor.get_ne());
 
-        assert_eq!(embeddings_tensor.nelements(), n_embd * 8 * n);
+        assert_eq!(embeddings_tensor.nelements(), n_embd *  n);
         unsafe {
             embeddings_tensor.read_data(0, bytemuck::cast_slice_mut(embeddings));
         }

--- a/crates/llm/examples/bench.rs
+++ b/crates/llm/examples/bench.rs
@@ -71,7 +71,9 @@ fn main() {
     let model_path = args.model_path.unwrap();
 
     //let queries = vec!["the cat sat on the mat", "the quick brown fox jumped over"];
+    //let queries = vec!["the cat sat on the mat"];
     let queries = vec!["the cat sat on the mat", "the cat sat on the mat"];
+
     // let queries = vec!["the quick brown fox jumped over"];
 
     // Load model
@@ -90,8 +92,8 @@ fn main() {
     let inference_parameters = llm::InferenceParameters::default();
 
     // Generate embeddings for query and comparands
-    get_batch_embeddings(model.as_ref(), &inference_parameters, &queries);
-    //get_embeddings(model.as_ref(), &inference_parameters, queries[0]);
+    //get_batch_embeddings(model.as_ref(), &inference_parameters, &queries);
+    get_embeddings(model.as_ref(), &inference_parameters, queries[0]);
 }
 
 fn get_batch_embeddings(
@@ -132,7 +134,7 @@ fn get_batch_embeddings(
     model.batch_evaluate(&mut session, &query_token_ids, &mut output_request);
     let _embeddings = output_request.embeddings.unwrap();
 
-    dbg!(&_embeddings[..64]);
+    dbg!(&_embeddings[384*8..384*8+7]);
 
     // Cast to ndarray reshape to (8, 384)
     // let _embeddings = Array3::from_shape_vec((8, 384, 1), _embeddings).unwrap();
@@ -188,7 +190,7 @@ fn get_embeddings(
         .collect::<Vec<_>>();
     model.evaluate(&mut session, &query_token_ids, &mut output_request);
     let _embeddings = output_request.embeddings.unwrap();
-    dbg!(&_embeddings[..64]);
+    dbg!(&_embeddings[..7]);
 
     // let _embeddings = Array2::from_shape_vec((7, 384), _embeddings).unwrap();
     // // // Get the mean over the first dimension (384, 2)

--- a/crates/llm/examples/bench.rs
+++ b/crates/llm/examples/bench.rs
@@ -92,8 +92,8 @@ fn main() {
     let inference_parameters = llm::InferenceParameters::default();
 
     // Generate embeddings for query and comparands
-    //get_batch_embeddings(model.as_ref(), &inference_parameters, &queries);
-    get_embeddings(model.as_ref(), &inference_parameters, queries[0]);
+    get_batch_embeddings(model.as_ref(), &inference_parameters, &queries);
+    //get_embeddings(model.as_ref(), &inference_parameters, queries[0]);
 }
 
 fn get_batch_embeddings(
@@ -134,7 +134,7 @@ fn get_batch_embeddings(
     model.batch_evaluate(&mut session, &query_token_ids, &mut output_request);
     let _embeddings = output_request.embeddings.unwrap();
 
-    dbg!(&_embeddings[384*8..384*8+7]);
+    dbg!(&_embeddings[..7]);
 
     // Cast to ndarray reshape to (8, 384)
     // let _embeddings = Array3::from_shape_vec((8, 384, 1), _embeddings).unwrap();

--- a/crates/llm/examples/bench.rs
+++ b/crates/llm/examples/bench.rs
@@ -134,7 +134,8 @@ fn get_batch_embeddings(
     model.batch_evaluate(&mut session, &query_token_ids, &mut output_request);
     let _embeddings = output_request.embeddings.unwrap();
 
-    dbg!(&_embeddings[..7]);
+    dbg!(&_embeddings[..10]);
+    dbg!(&_embeddings[128*384..128*384+10]);
 
     // Cast to ndarray reshape to (8, 384)
     // let _embeddings = Array3::from_shape_vec((8, 384, 1), _embeddings).unwrap();

--- a/crates/llm/examples/bench.rs
+++ b/crates/llm/examples/bench.rs
@@ -72,7 +72,7 @@ fn main() {
 
     //let queries = vec!["the cat sat on the mat", "the quick brown fox jumped over"];
     //let queries = vec!["the cat sat on the mat"];
-    let queries = vec!["the cat sat on the mat", "the cat sat on the mat"];
+    let queries = vec!["the cat sat on the mat", "the quick brown fox jumped over"];
 
     // let queries = vec!["the quick brown fox jumped over"];
 
@@ -134,8 +134,9 @@ fn get_batch_embeddings(
     model.batch_evaluate(&mut session, &query_token_ids, &mut output_request);
     let _embeddings = output_request.embeddings.unwrap();
 
-    dbg!(&_embeddings[..10]);
-    dbg!(&_embeddings[128*384..128*384+10]);
+    //dbg!(&_embeddings[..10]);
+    //dbg!(&_embeddings[128*5..128*5+10]);
+    //dbg!(&_embeddings[128*384..128*384+10]);
 
     // Cast to ndarray reshape to (8, 384)
     // let _embeddings = Array3::from_shape_vec((8, 384, 1), _embeddings).unwrap();
@@ -146,15 +147,15 @@ fn get_batch_embeddings(
     // // Print the first 10 elements
     // dbg!(&_embeddings.to_vec()[..10]);
 
-    // let _embeddings = Array3::from_shape_vec((8, 384, 2), _embeddings).unwrap();
+    let _embeddings = Array3::from_shape_vec((query_token_ids.len(), 384, 128), _embeddings).unwrap();
     // // // Get the mean over the first dimension (384, 2)
-    // let _embeddings = _embeddings.mean_axis(ndarray::Axis(0)).unwrap();
+    let _embeddings = _embeddings.sum_axis(ndarray::Axis(2));
     // // Permute the axes to (2, 384)
     // // Iterate over rows in the matrix
-    // for row in _embeddings.t().rows() {
-    //     // let row = row.into_shape((384,)).unwrap();
-    //     dbg!(&row.to_vec()[..10]);
-    // }
+    for row in _embeddings.rows() {
+        // let row = row.into_shape((384,)).unwrap();
+        dbg!(&row.to_vec()[..384]);
+    }
     // // let _embeddings = _embeddings.index_axis_move(ndarray::Axis(1), 0);
     // // dbg!(&_embeddings.shape());
     // // // Print the first 10 elements

--- a/crates/llm/examples/bench.rs
+++ b/crates/llm/examples/bench.rs
@@ -134,10 +134,10 @@ fn get_batch_embeddings(
     let _embeddings = output_request.embeddings.unwrap();
     
     // Embeddings have size [batch_size, 384]
-    // First 10 elements of example 0
-    dbg!(&_embeddings[..10]);
-    // // First 10 elements of example 1
-    dbg!(&_embeddings[384..384+10]);
+    // First 16 elements of example 0
+    dbg!(&_embeddings[..16]);
+    // // First 16 elements of example 1
+    dbg!(&_embeddings[384..384+16]);
     
     BenchResult {
         elapsed: s.elapsed(),

--- a/crates/llm/examples/bench.rs
+++ b/crates/llm/examples/bench.rs
@@ -62,16 +62,16 @@ impl std::ops::Add<BenchResult> for BenchResult {
 
 fn main() {
     let mut args = Args::parse();
-    args.tokenizer_path = Some("/Users/gabriel/work/research/rt-bench/model/tokenizer.json".into());
+    args.tokenizer_path = Some("/Users/rafael/workspace/rafael_bloop/all-MiniLM-L6-v2/tokenizer.json".into());
     args.model_path =
-        Some("/Users/gabriel/work/research/rt-bench/model/ggml-model-q4_0.bin".into());
+        Some("/Users/rafael/workspace/rafael_bloop/ggml-model-q4_0.bin".into());
 
     let tokenizer_source = args.to_tokenizer_source();
     let model_architecture = llm::ModelArchitecture::Bert;
     let model_path = args.model_path.unwrap();
 
-    let queries = vec!["the cat sat on the mat", "the quick brown fox jumped over"];
-    // let queries = vec!["the cat sat on the mat"];
+    //let queries = vec!["the cat sat on the mat", "the quick brown fox jumped over"];
+    let queries = vec!["the cat sat on the mat", "the cat sat on the mat"];
     // let queries = vec!["the quick brown fox jumped over"];
 
     // Load model
@@ -91,6 +91,7 @@ fn main() {
 
     // Generate embeddings for query and comparands
     get_batch_embeddings(model.as_ref(), &inference_parameters, &queries);
+    //get_embeddings(model.as_ref(), &inference_parameters, queries[0]);
 }
 
 fn get_batch_embeddings(
@@ -131,7 +132,7 @@ fn get_batch_embeddings(
     model.batch_evaluate(&mut session, &query_token_ids, &mut output_request);
     let _embeddings = output_request.embeddings.unwrap();
 
-    dbg!(&_embeddings[..8]);
+    dbg!(&_embeddings[..64]);
 
     // Cast to ndarray reshape to (8, 384)
     // let _embeddings = Array3::from_shape_vec((8, 384, 1), _embeddings).unwrap();
@@ -142,19 +143,19 @@ fn get_batch_embeddings(
     // // Print the first 10 elements
     // dbg!(&_embeddings.to_vec()[..10]);
 
-    let _embeddings = Array3::from_shape_vec((8, 384, 2), _embeddings).unwrap();
-    // // Get the mean over the first dimension (384, 2)
-    let _embeddings = _embeddings.mean_axis(ndarray::Axis(0)).unwrap();
-    // Permute the axes to (2, 384)
-    // Iterate over rows in the matrix
-    for row in _embeddings.t().rows() {
-        // let row = row.into_shape((384,)).unwrap();
-        dbg!(&row.to_vec()[..10]);
-    }
-    // let _embeddings = _embeddings.index_axis_move(ndarray::Axis(1), 0);
-    // dbg!(&_embeddings.shape());
-    // // Print the first 10 elements
-    // dbg!(&_embeddings);
+    // let _embeddings = Array3::from_shape_vec((8, 384, 2), _embeddings).unwrap();
+    // // // Get the mean over the first dimension (384, 2)
+    // let _embeddings = _embeddings.mean_axis(ndarray::Axis(0)).unwrap();
+    // // Permute the axes to (2, 384)
+    // // Iterate over rows in the matrix
+    // for row in _embeddings.t().rows() {
+    //     // let row = row.into_shape((384,)).unwrap();
+    //     dbg!(&row.to_vec()[..10]);
+    // }
+    // // let _embeddings = _embeddings.index_axis_move(ndarray::Axis(1), 0);
+    // // dbg!(&_embeddings.shape());
+    // // // Print the first 10 elements
+    // // dbg!(&_embeddings);
 
     BenchResult {
         elapsed: s.elapsed(),
@@ -187,6 +188,17 @@ fn get_embeddings(
         .collect::<Vec<_>>();
     model.evaluate(&mut session, &query_token_ids, &mut output_request);
     let _embeddings = output_request.embeddings.unwrap();
+    dbg!(&_embeddings[..64]);
+
+    // let _embeddings = Array2::from_shape_vec((7, 384), _embeddings).unwrap();
+    // // // Get the mean over the first dimension (384, 2)
+    // let _embeddings = _embeddings.mean_axis(ndarray::Axis(0)).unwrap();
+    // // Permute the axes to (2, 384)
+    // // Iterate over rows in the matrix
+    // for row in _embeddings.t().rows() {
+    //     // let row = row.into_shape((384,)).unwrap();
+    //     dbg!(&row.to_vec()[..10]);
+    // }
     BenchResult {
         elapsed: s.elapsed(),
         query_token_count: query_token_ids.len(),

--- a/crates/models/bert/Cargo.toml
+++ b/crates/models/bert/Cargo.toml
@@ -11,4 +11,5 @@ readme = "../../../README.md"
 bytemuck.workspace = true
 llm-base = { path = "../../llm-base", version = "0.2.0-dev" }
 tracing = { version = "0.1", features = ["log"] }
+num-traits = "0.2"
 

--- a/crates/models/bert/src/lib.rs
+++ b/crates/models/bert/src/lib.rs
@@ -391,7 +391,7 @@ impl KnownModel for Bert {
         common::extract_embeddings(output_request, &outputs.embedding_result, n_embd, input_len);
     }
 
-    /// Blah, blah, blah
+    /// Run BERT inference for batched examples
     #[tracing::instrument(level = "trace", skip_all)]
     fn batch_evaluate(
         &self,
@@ -400,9 +400,11 @@ impl KnownModel for Bert {
         output_request: &mut OutputRequest,
     ) {
         let batch_size = input_tokens.len();
-        dbg!(batch_size);
+        // sequence_len is fixed sized (all examples are padded to this length)
         let sequence_len: usize = input_tokens[0].len();
 
+        // For every token, the number of non-padding tokens in the example (used for mean pooling)
+        // [sequence_len * batch_size]
         let example_len: Vec<u32> = input_tokens.iter().map(
             |example| {
                 let e_lens: Vec<u32> = vec![example.iter().map(|&i| if i == self.pad_token_id().unwrap(){0} else {1}).sum(); sequence_len];
@@ -410,8 +412,8 @@ impl KnownModel for Bert {
             }
         ).flatten().collect();
 
-
-        // TODO: Keep track of unpadded sequence lengths
+        // The actual tokens after tokenizer
+        // [sequence_len * batch_size]
         let input_tokens = input_tokens
             .iter()
             .flat_map(|row| {
@@ -421,7 +423,6 @@ impl KnownModel for Bert {
                 row
             })
             .collect::<Vec<_>>();
-        // dbg!(&input_tokens);
 
 
         // If input token is equal to pad token, then set to the largest negative float32, otherwise make it 0.0
@@ -435,8 +436,8 @@ impl KnownModel for Bert {
                 }
             })
             .collect::<Vec<_>>();
-        dbg!(&attention_mask);
 
+        // 1/(number of non-padding tokens in example) for each token    
         let binary_attention_mask = input_tokens
             .iter().zip(example_len.iter())
             .map(|(&tok, &e_len)| {
@@ -450,7 +451,6 @@ impl KnownModel for Bert {
 
         // batch_size * sequence_len
         let input_len = input_tokens.len();
-        dbg!(input_len);
 
         let _session_len = session.n_past;
         let _ctx_size = self.params.context_size;
@@ -485,7 +485,7 @@ impl KnownModel for Bert {
                 ctx0.new_tensor_4d(llm_base::ElementType::F32, input_len, 1, 1, 1);
             unsafe { bin_attention_mask_tensor.write_data(bytemuck::cast_slice(&binary_attention_mask)) }; 
 
-            // IL = word_embeddings + token_types + position_embeddingso
+            // IL = word_embeddings + token_types + position_embeddings
             {
                 // token-types: a zero tensor
                 let mut token_types = ctx0.new_tensor_1d(llm_base::ElementType::I32, input_len);
@@ -598,32 +598,21 @@ impl KnownModel for Bert {
                         ),
                     );
 
-                    // You could reshape 4 dimensional input tensors from [a,b,c,d] to [a,b,c*d,1]
-                    // before using mul_mat and then reshape the result [x,y,c*d] back to [x,y,c,d].
-                    // Make 3d for matmul
+                    // Merge batch and heads dimensions
                     let q = ctx0.op_reshape_3d(&q, d_head, sequence_len, n_head * batch_size);
                     let k = ctx0.op_reshape_3d(&k, d_head, sequence_len, n_head * batch_size);
                     v = ctx0.op_reshape_3d(&v, d_head, sequence_len, n_head * batch_size);
 
                     let mut kq = ctx0.op_mul_mat(&k, &q);
 
-                    
-
-
-                    // Reshape back to 4d
-                    // kq = ctx0.op_reshape_4d(&kq, sequence_len, sequence_len, n_head, batch_size);
-
-                    // TODO: look into op_scale_inplace and op_soft_max_inplace
                     kq = ctx0.op_scale(
                         &kq,
                         &ctx0.new_f32(1.0 / ((n_embd as f32 / n_head as f32).sqrt())),
                     );
 
-                    // Add attention mask (256, 256, 12, 2)
-                    // Reshape attention mask (256, 2)
-
-
+                    // Split batch and head in separate dimensions
                     let kq = ctx0.op_reshape_4d(&kq, sequence_len,sequence_len, n_head, batch_size);
+                    // Move batch dim to the first dim 
                     let kq = ctx0.op_permute(&kq, (0,3,2,1));
                     let kq = ctx0.op_cpy(
                         &kq,
@@ -635,13 +624,13 @@ impl KnownModel for Bert {
                             sequence_len,
                         ),
                     );
+                    // Merge seq_len and batch dimension
                     let kq = ctx0.op_reshape_4d(&kq, sequence_len*batch_size, n_head, sequence_len,1);
 
-                    // let attention_mask_tensor =
-                    //     ctx0.op_reshape_4d(&attention_mask_tensor, sequence_len, 1, 1, batch_size);
+                    // attention mask is 1D [sequence_len*batch_size]
+                    // Add is broadcasted
                     let kq = ctx0.op_add(&kq, &attention_mask_tensor);
-                    //intermediate_tensor = kq.share();
-
+                    // Reverting dimensions back to [seq_len, seq_len, n_head, bsz]
                     let kq = ctx0.op_reshape_4d(&kq, sequence_len, batch_size, n_head, sequence_len);
                     let kq = ctx0.op_permute(&kq, (0,3,2,1));
                     let kq = ctx0.op_cpy(
@@ -655,37 +644,15 @@ impl KnownModel for Bert {
                         ),
                     );
 
+                    // Merge head and batch dim 
                     let kq = ctx0.op_reshape_4d(&kq, sequence_len,sequence_len, n_head* batch_size,1);
-
-
-                    let kq = ctx0.op_soft_max(&kq); // (256, 256, 12, 8)
-                                                // v (32, 256, 12, 8)
+                    let kq = ctx0.op_soft_max(&kq); 
 
                     v = ctx0.op_cont(&ctx0.op_transpose(&v));
-                    // v (256, 32, 12, 8)
-
-                    // let kq =
-                    //     ctx0.op_reshape_3d(&kq, sequence_len, sequence_len, n_head * batch_size); // (256, 256, 96, 1)
-                    // let v = ctx0.op_reshape_3d(&v, sequence_len, d_head, n_head * batch_size); // (256, 32, 96, 1)
-
                     let kqv = &ctx0.op_mul_mat(&v, &kq);
-                    // kqv (32, 256, 96, 1)
-
                     // Reshape back to 4d
                     let kqv = ctx0.op_reshape_4d(kqv, d_head, sequence_len, n_head, batch_size);
-                    // kqv (32, 256, 12, 8)
-
-
-
-                    // Permute
                     let kqv = ctx0.op_permute(&kqv, (0, 2, 1, 3));
-
-
-
-                    // let kqv = ctx0.op_reshape_4d(&kqv, d_head, n_head, sequence_len, batch_size);
-                    // kqv (32, 12, 256, 8)
-
-
                     current = ctx0.op_cpy(
                         &kqv,
                         &ctx0.new_tensor_3d(ggml::Type::F32, n_embd, sequence_len, batch_size),
@@ -698,10 +665,6 @@ impl KnownModel for Bert {
                     &ctx0.op_mul_mat(&self.layers[il].o_w, &current),
                     &self.layers[il].o_b,
                 );
-
-
-                
-
 
                 // re-add the layer input
                 current = ctx0.op_add(&current, &input_layer);
@@ -738,51 +701,24 @@ impl KnownModel for Bert {
                     );
                 }
 
-
-
                 // input for next layer
                 input_layer = current;
             }
+
+            // Merge seq_len and batch in first dimension
             input_layer = ctx0.op_cont(&ctx0.op_permute(&input_layer, (2,0,1,3)));
             input_layer = ctx0.op_reshape_2d(&input_layer, batch_size*sequence_len,n_embd);
+            // Multiplicative masking + weighting
             input_layer = ctx0.op_mul(&input_layer, &bin_attention_mask_tensor);
             input_layer = ctx0.op_reshape_3d(&input_layer, sequence_len,batch_size,n_embd);
+            // Reduce_sum over first dimension (pooling)
+            let mut sum =
+                 ctx0.new_tensor_2d(llm_base::ElementType::F16, sequence_len,1);
+            sum = ctx0.set_f32(&sum, 1.0);
+            input_layer = ctx0.op_mul_mat(&sum, &input_layer);
+            input_layer = ctx0.op_cont(&ctx0.op_permute(&input_layer, (2,1,0,3)));
 
-            // let mut sum =
-            //     ctx0.new_tensor_1d(llm_base::ElementType::F32, sequence_len);
-            //  sum = ctx0.set_f32(&sum, 1.0);
-
-            //input_layer = ctx0.op_mul_mat(&sum, &input_layer);
-
-            input_layer = ctx0.op_cont(&ctx0.op_permute(&input_layer, (0,2,1,3)));
-
-
-
-            // Slice the tensor to get the first row in the batch
-
-            // ctx0.set_offloading(false);
-            // pooler
-            // let mut sum =
-            //     ctx0.new_tensor_3d(llm_base::ElementType::F32, sequence_len, 1, batch_size);
-            // sum = ctx0.set_f32(&sum, 1.0);
-            // sum = ctx0.op_mul(&sum, &scaling_factor_tensor);
-
-            // // (256, 384, 2, 1) * (256, 1, 2, 1)
-            // input_layer = ctx0.op_mul(&input_layer, &binary_attention_mask_tensor);
-
-            // input_layer = ctx0.op_cpy(
-            //     &input_layer,
-            //     &ctx0.new_tensor_3d(ggml::Type::F16, sequence_len, n_embd, batch_size),
-            // );
-            // input_layer =
-            //     ctx0.op_reshape_2d(&ctx0.op_mul_mat(&input_layer, &sum), n_embd, batch_size);
-
-            // normalizer
-            // let length = ctx0.op_sqrt(&ctx0.op_sum(&ctx0.op_sqr(&input_layer)));
-
-            // input_layer = ctx0.op_scale(&input_layer, &ctx0.op_div(&ctx0.new_f32(1.0), &length));
-            // println!("writing dot graph");
-
+            //TODO: op_norm
             (
                 gf,
                 GraphOutputs {
@@ -799,7 +735,7 @@ impl KnownModel for Bert {
             output_request,
             &outputs.embedding_result,
             n_embd,
-            batch_size* sequence_len,
+            batch_size,
         );
     }
 

--- a/crates/models/bert/src/lib.rs
+++ b/crates/models/bert/src/lib.rs
@@ -717,8 +717,13 @@ impl KnownModel for Bert {
             sum = ctx0.set_f32(&sum, 1.0);
             input_layer = ctx0.op_mul_mat(&sum, &input_layer);
             input_layer = ctx0.op_cont(&ctx0.op_permute(&input_layer, (2,1,0,3)));
+            // Normalization
+            input_layer = ctx0.op_norm(&input_layer);
+            input_layer = ctx0.op_scale(
+                &input_layer,
+                &ctx0.new_f32(1.0 / ((n_embd as f32).sqrt())),
+            );
 
-            //TODO: op_norm
             (
                 gf,
                 GraphOutputs {

--- a/crates/models/bert/src/lib.rs
+++ b/crates/models/bert/src/lib.rs
@@ -748,13 +748,13 @@ impl KnownModel for Bert {
             input_layer = ctx0.op_mul(&input_layer, &bin_attention_mask_tensor);
             input_layer = ctx0.op_reshape_3d(&input_layer, sequence_len,batch_size,n_embd);
 
-            let mut sum =
-                ctx0.new_tensor_1d(llm_base::ElementType::F32, sequence_len);
-             sum = ctx0.set_f32(&sum, 1.0);
+            // let mut sum =
+            //     ctx0.new_tensor_1d(llm_base::ElementType::F32, sequence_len);
+            //  sum = ctx0.set_f32(&sum, 1.0);
 
-            input_layer = ctx0.op_mul_mat(&sum, &input_layer);
+            //input_layer = ctx0.op_mul_mat(&sum, &input_layer);
 
-            input_layer = ctx0.op_cont(&ctx0.op_permute(&input_layer, (2,1,0,3)));
+            input_layer = ctx0.op_cont(&ctx0.op_permute(&input_layer, (0,2,1,3)));
 
 
 
@@ -799,7 +799,7 @@ impl KnownModel for Bert {
             output_request,
             &outputs.embedding_result,
             n_embd,
-            batch_size,
+            batch_size* sequence_len,
         );
     }
 


### PR DESCRIPTION
- for n string queries, we tokenize each of them with fixed length (128) and create a tensor of [n, 128]
- padding is applied for queries with length < 128
- evaluate is generalized to batch_evaluate
- this is done by merging batch and head dimensions for matmuls and merging sequence_len and batch dimensions for masking and pooling
- this PR focus on "merging sequence_len and batch dimensions for masking and pooling" so results are exactly the same between evaluate and batch_evaluate
- variable query length mean pooling is added
-  output is of shape (384, n)
- each embedding is not normalized to 1

Tests

Per token embeddings have the same EXACT values between evaluate and batch_evaluate (evaluate has no masking, so to test this, I truncated the evaluate input to the number of non-padding tokens)

Avg pooled embeddings are approximately equal to torch (small difference due to quantization)